### PR TITLE
[Nexus] initial release change for new Kodi 20 Nexus version

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,1 +1,1 @@
-buildPlugin(version: "Matrix", platforms: ['ubuntu-ppa'])
+buildPlugin(version: "Nexus", platforms: ['ubuntu-ppa'])

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The following instructions assume you will have built Kodi already in the `kodi-
 suggested by the README.
 
 1. `git clone --branch master https://github.com/xbmc/xbmc.git`
-2. `git clone --branch Matrix https://github.com/xbmc/audiodecoder.fluidsynth.git`
+2. `git clone --branch Nexus https://github.com/xbmc/audiodecoder.fluidsynth.git`
 3. `cd audiodecoder.fluidsynth && mkdir build && cd build`
 4. `cmake -DADDONS_TO_BUILD=audiodecoder.fluidsynth -DADDON_SRC_PREFIX=../.. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=../../xbmc/kodi-build/addons -DPACKAGE_ZIP=1 ../../xbmc/cmake/addons`
 5. `make`

--- a/audiodecoder.fluidsynth/addon.xml.in
+++ b/audiodecoder.fluidsynth/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.fluidsynth"
-  version="3.0.0"
+  version="20.0.0"
   name="FluidSynth MIDI Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>


### PR DESCRIPTION
This change the builds to Kodi Nexus.

Further is the version to 20.0.0 increased to have equal to Kodi and to see on which Version this addon works.