### PR TITLE
[Matrix] Allow bulding without OpenMP

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 find_package(Kodi REQUIRED)
 find_package(FluidSynth REQUIRED)
 find_package(LibSndFile REQUIRED)
+find_package(OpenMP)
 
 include(ExternalProject)
 
@@ -16,7 +17,7 @@ include_directories(${KODI_INCLUDE_DIR}/..
 set(FLUID_SOURCES src/FluidDecoder.cpp)
 set(FLUID_HEADERS src/FluidDecoder.h)
 
-set(DEPLIBS ${FLUIDSYNTH_LIBRARIES} ${LIBSNDFILE_LIBRARIES} gomp)
+set(DEPLIBS ${FLUIDSYNTH_LIBRARIES} ${LIBSNDFILE_LIBRARIES} ${OpenMP_CXX_LIBRARIES})
 
 # the cmake var SOUND_FONT can be used to set a platform specific default sound font
 # e.g. -DSOUND_FONT=/path/to/some_sound_font.sf2


### PR DESCRIPTION
OpenMP is optional for fluidsynth, make it optional for addon too.

Backport of #27